### PR TITLE
Updated mutations from official client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-modules:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/plugins/module_utils/borgbase_client.py
+++ b/plugins/module_utils/borgbase_client.py
@@ -81,13 +81,13 @@ query repoList {
 
     REPO_ADD = '''
 mutation repoAdd(
-  $name: String
+  $name: String!
   $quota: Int
   $quotaEnabled: Boolean
   $appendOnlyKeys: [String]
   $fullAccessKeys: [String]
   $alertDays: Int
-  $region: String
+  $region: String!
   $borgVersion: String
   ) {
     repoAdd(
@@ -103,6 +103,8 @@ mutation repoAdd(
       repoAdded {
         id
         name
+        region
+        repoPath
       }
     }
 }
@@ -134,6 +136,8 @@ mutation repoEdit(
       repoEdited {
         id
         name
+        region
+        repoPath
       }
     }
 }


### PR DESCRIPTION
I've noticed that the ansible module fails when trying to create a new repo on BorgBase (but is fine for new SSH keys). So I traced the errore at some mutations that probably needs to be updated to latest version, as described in the official client: 
https://github.com/borgbase/borgbase-api-client/blob/master/borgbase_api_client/mutations.py

