### PR TITLE
fix checking between provided key and remote key (#12)

### DIFF
--- a/plugins/modules/borgbase_ssh.py
+++ b/plugins/modules/borgbase_ssh.py
@@ -236,7 +236,10 @@ def runModule():
             addRequired = False
 
             if keyExists and stateExists:
-                if module.params['key'].strip() != foundKey['keyData']:
+                # key provided can have a optional keyname, e.g.: "ssh-ed25519 AAAAC3Nd... root@localhost"
+                # only keep algorithm and data
+                providedKey = " ".join(module.params['key'].strip().split()[:2])
+                if providedKey != foundKey['keyData']:
                     deleteRequired = True
                     addRequired = True
 


### PR DESCRIPTION
This is a follow-up of #12.

The issue described there is that an ssh key can have an optional field, the key name, which is not stored in Borgbase. 

The local key is formatted as "*algorithm data keyname*", whereas on Borgbase it's stored without the *keyname*. Therefore, the module always uploads the key on each playbook run.

The implemented solution just consist in removing the *keyname* when we have to compare.